### PR TITLE
changing the skull stripper plan to only look for skull stripper labels

### DIFF
--- a/fets/bin/federations/plans/pt_3dresunet_ss_brainmagebrats.yaml
+++ b/fets/bin/federations/plans/pt_3dresunet_ss_brainmagebrats.yaml
@@ -37,9 +37,10 @@ data_object_init:
   init_kwargs: 
     batch_size: 1
     patch_size: [128,128,128]
-    feature_modes: ["_t1.nii", "_t2.nii", "_flair.nii", "_t1ce.nii"]
+    feature_modes: ["_t1.nii.gz", "_t2.nii.gz", "_flair.nii.gz", "_t1ce.nii.gz"]
     divisibility_factor: 16
     class_label_map: {0: 0, 1: 1}
+    label_tags: ['skull_stripper_seg.nii.gz']
 
 inference:
   allowed: True

--- a/fets/models/pytorch/brainmage/brainmage.py
+++ b/fets/models/pytorch/brainmage/brainmage.py
@@ -116,6 +116,10 @@ class BrainMaGeModel(PyTorchFLModel):
 
         # TODO: To sync learning rate cycle, we assume single epoch per round and that the data loader is allowing partial batches!!!
         step_size = int(np.ceil(self.data.get_training_data_size()/self.data.batch_size))
+        if step_size == 0:
+            # This only happens when we have no training data so will not be using the optimizer
+            step_size = 1
+            print("\nNo training data is present, so cyclic optimizer being set with step size of 1.\n")
         clr = cyclical_lr(step_size, min_lr = 0.000001, max_lr = 0.001)
         self.lr_scheduler = torch.optim.lr_scheduler.LambdaLR(self.optimizer, [clr])
         sys.stdout.flush()


### PR DESCRIPTION
when creating training data, and allow for setting the cyclic lr step
size of 1 (as a dummy value) for training when no training labels are
present.