### PR TITLE
Changes to pt_3dresnet allowing for a softmax output when using one-h…

### DIFF
--- a/fets/data/pytorch/ptbrainmagedata.py
+++ b/fets/data/pytorch/ptbrainmagedata.py
@@ -112,6 +112,11 @@ class PyTorchBrainMaGeData(PyTorchFLDataInMemory):
 
         # if we are performing binary classification per pixel, we will disable one_hot conversion of labels
         self.binary_classification =  self.n_classes == 2
+
+        # there is an assumption that for binary classification, new classes are exactly 0 and 1
+        if self.binary_classification:
+            if set(class_label_map.values()) != set([0, 1]):
+                raise ValueError("When performing binary classification, the new labels should be 0 and 1")
     
 
         

--- a/fets/models/pytorch/pt_3dresunet/pt_3dresunet.py
+++ b/fets/models/pytorch/pt_3dresunet/pt_3dresunet.py
@@ -54,7 +54,7 @@ class PyTorch3DResUNet(BrainMaGeModel):
         self.us_1 = UpsamplingModule(self.base_filters*4, self.base_filters*2)
         self.de_1 = DecodingModule(self.base_filters*4, self.base_filters*2, res=True)
         self.us_0 = UpsamplingModule(self.base_filters*2, self.base_filters)
-        self.out = out_conv(self.base_filters*2, self.label_channels, res=True)
+        self.out = out_conv(self.base_filters*2, self.label_channels, self.binary_classification, res=True)
 
         if print_model:
             print(self)


### PR DESCRIPTION
…ot encoding of labels, and simply applying sigmoid to map to [0,1] otherwise.

Within the outconv layer of pt_3dresunet, a softmax was being applied (along axis=1) just before the output. This is appropriate for the non-binary classification case (when output is one-hot encoded), but produces a 1.0 output in the case of single channel output.

## Proposed Changes
  - Pass the binary_classification boolean from the model to the outconv layer
  - When binary_classification is True, apply sigmoid, otherwise softmax along axis=1 as before.
  - Incorporate a check in the data object that if performing binary classification make sure that the values in the class map are exactly {0, 1} as values outside of [0, 1] will not be reachable with this use of sigmoid.