### PR TITLE
add a parameter to data object constructor so we can tell

### DIFF
--- a/fets/data/pytorch/gandlf_data.py
+++ b/fets/data/pytorch/gandlf_data.py
@@ -21,10 +21,12 @@ class GANDLFData(object):
     def __init__(self, 
                  data_path, 
                  divisibility_factor,
+                 in_memory=False,
                  **kwargs):
 
         self.data_path = data_path
         self.divisibility_factor = divisibility_factor
+        self.in_memory = in_memory
 
         print("\n\n###########################################################")
         print("THE PARAMS BELOW DO NOT APPLY AND SHOULD BE DISREGARDED ...")
@@ -105,7 +107,8 @@ class GANDLFData(object):
                                                sampler=self.patch_sampler, 
                                                train=train, 
                                                augmentations=augmentations, 
-                                               preprocessing=self.preprocessing)
+                                               preprocessing=self.preprocessing, 
+                                               in_memory=self.in_memory)
             loader = DataLoader(DataForTorch, batch_size=self.batch_size)
             
             companion_loader = None


### PR DESCRIPTION
GANDLF.data.ImagesFromDataFram that we want an in_memory loader

Fixes issue #(Enter issue number here)

## Proposed Changes
  -
  -
  -