### PR TITLE
Fix import errors for internal modules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "GANDLF"]
-	path = GANDLF
+[submodule "GANDLF_module"]
+	path = GANDLF_module
 	url = https://github.com/CBICA/GANDLF.git

--- a/fets/bin/brainmage_validation_outputs_to_disk.py
+++ b/fets/bin/brainmage_validation_outputs_to_disk.py
@@ -1,3 +1,6 @@
+import sys
+sys.path.append('./OpenFederatedLearning/submodules/fets_ai/Algorithms/')
+
 import argparse
 import os
 import shutil

--- a/fets/bin/brainmage_validation_scores_to_disk.py
+++ b/fets/bin/brainmage_validation_scores_to_disk.py
@@ -1,3 +1,6 @@
+import sys
+sys.path.append('./OpenFederatedLearning/submodules/fets_ai/Algorithms/')
+
 import argparse
 import os
 import shutil

--- a/fets/bin/create_split_links_and_csvs.py
+++ b/fets/bin/create_split_links_and_csvs.py
@@ -1,3 +1,6 @@
+import sys
+sys.path.append('./OpenFederatedLearning/submodules/fets_ai/Algorithms/GANDLF_module/')
+
 import argparse
 import os
 import numpy as np

--- a/fets/data/pytorch/gandlf_data.py
+++ b/fets/data/pytorch/gandlf_data.py
@@ -1,6 +1,8 @@
 
 # TODO:insert header pointing to GANDLF repo inclusion
 # TODO: Should the validation patch sampler be different from the training one?
+import sys
+sys.path.append('./OpenFederatedLearning/submodules/fets_ai/Algorithms/GANDLF_module/')
 
 import os, pathlib
 os.environ['TORCHIO_HIDE_CITATION_PROMPT'] = '1' # hides torchio citation request, see https://github.com/fepegar/torchio/issues/235

--- a/fets/models/pytorch/brainmage/brainmage.py
+++ b/fets/models/pytorch/brainmage/brainmage.py
@@ -10,6 +10,8 @@
 # DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
 # WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 # This is a 3-clause BSD license as defined in https://opensource.org/licenses/BSD-3-Clause
+import sys
+sys.path.append('./OpenFederatedLearning/submodules/fets_ai/Algorithms/GANDLF_module/')
 
 import os
 os.environ['TORCHIO_HIDE_CITATION_PROMPT'] = '1' # hides torchio citation request, see https://github.com/fepegar/torchio/issues/235

--- a/fets/models/pytorch/brainmage/losses.py
+++ b/fets/models/pytorch/brainmage/losses.py
@@ -10,7 +10,9 @@
 # DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
 # WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 # This is a 3-clause BSD license as defined in https://opensource.org/licenses/BSD-3-Clause
- 
+import sys
+sys.path.append('./OpenFederatedLearning/submodules/fets_ai/Algorithms/GANDLF_module/')
+
 import numpy as np
 import torch
 from medpy.metric.binary import hd95


### PR DESCRIPTION
## Proposed Changes
  - Rename `GANDLF` submodule to `GANDLF_module` to prevent conflicting imports inside of the `fets` folder
  - Use `sys.path.append('./OpenFederatedLearning/submodules/fets_ai/Algorithms/')` in files which require imports from the `fets` module
  - Use `sys.path.append('./OpenFederatedLearning/submodules/fets_ai/Algorithms/GANDLF_module')` in files which require imports from the `GANDLF` module
  
## Potential Breaking Changes
- This PR requires users to run FeTS CLI programs (such as FeTS_CLI_Inference) from their ${fets_root_dir}/bin directory. This limitation could be addressed in a future PR by playing with the `__init__.py` files in each of the modules, thereby eliminating the need to append modules to the system path.

## Contact
Email (work): gamble.cooper@mayo.edu
Email (personal): gamble.cooper23@gmail.com