### PR TITLE
Fix changes from sklearn to scikit-learn

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,5 +11,5 @@ setup(name='fets',
                 'fets.models.pytorch.nnunet',
                 'fets.data',
                 'fets.data.pytorch'],
-      install_requires=['protobuf', 'grpcio', 'tqdm', 'coloredlogs', 'nibabel', 'sklearn', 'nnUNet==1.6.6', 'batchgenerators==0.21', 'opencv-python', 'MedPy==0.4.0']
+      install_requires=['protobuf', 'grpcio', 'tqdm', 'coloredlogs', 'nibabel', 'scikit-learn', 'nnUNet==1.6.6', 'batchgenerators==0.21', 'opencv-python', 'MedPy==0.4.0']
 )


### PR DESCRIPTION
Fixes issue #(Enter issue number here)
https://github.com/FeTS-AI/Algorithms/issues/88
## Proposed Changes
  - In this PR, I fixed the error when installing the `sklearn` library by changing it to `scikit-learn`.
  - [Resolving fixes this error is that when the user runs setup.py, the error doesn't occur.](https://github.com/FeTS-AI/Challenge/blob/524d6b9f489ba852d601a437839abd937e5cab89/Task_1/setup.py#L33)
 ## Contact
Email(work): M23047@hallym.ac.kr
Email(personal) : asy10092@gmail.com
 